### PR TITLE
트리의 지름

### DIFF
--- a/ChanhuiSeok/[5]백준/1167-트리의 지름.cpp
+++ b/ChanhuiSeok/[5]백준/1167-트리의 지름.cpp
@@ -1,0 +1,66 @@
+#include <iostream>
+#include <vector>
+#include <queue>
+#include <algorithm>
+
+using namespace std;
+
+int V;
+vector< vector< pair<int, int> >> node;
+bool visit[100001];
+
+int leafNode;
+int maxLength = -1;
+
+// 특정한 루트 노드에서 가장 멀리 떨어진 노드 찾기
+void dfs(int cur, int sum) {	
+	visit[cur] = true;
+
+	for (auto next : node[cur]) {
+		int nextNum = next.first;
+		int nextLength = next.second;
+		if (visit[nextNum]) continue;
+		
+		if (maxLength < sum + nextLength) {
+			leafNode = next.first;
+			maxLength = sum + nextLength;
+		}
+		dfs(next.first, sum + nextLength);
+	}
+}
+
+
+int main() {
+	
+	ios::sync_with_stdio(0);
+	cin.tie(0);
+	cout.tie(0);
+	int v, w, cur;
+
+	cin >> V;
+	node.resize(V + 1);
+
+	for (int i = 0; i < V; i++) {
+		cin >> cur;
+		while (1) {		
+			cin >> v;
+			if (v == -1) break;
+			cin >> w;
+			node[cur].push_back({ v, w });
+		}
+	}
+
+	// 1 찾기
+	dfs(1, 0);
+
+	// 초기화
+	maxLength = -1;
+	for (int i = 0; i < V + 1; i++)
+		visit[i] = false;
+
+	// 2 찾기
+	dfs(leafNode, 0);
+
+	cout << maxLength;
+	return 0;
+}


### PR DESCRIPTION
##### **📘 풀이한 문제**

- 1167 - 트리의 지름 : https://www.acmicpc.net/problem/1167

------

##### **⭐ 문제에서 주로 사용한 알고리즘**

* dfs를 구현하여 문제를 풀었습니다.

------

##### **📜 대략적인 코드 설명**

* 아무 노드를 잡고, 그 노드에서 거리값 상으로 가장 멀리 떨어진 노드 a를 dfs로 찾습니다.
가장 멀리 떨어진 노드 a를 구했으면, 노드 a에서 다시 거리값 상으로 가장 멀리 떨어진 노드 b를 dfs로 구합니다. 이 때, 노드 a와 노드 b 사이의 거리가 정답이 됩니다.
* 트리는 일자로 쭉 폈을 때 **리프 - 리프 노드 간의 거리**가 트리의 지름이 될 수 있는 후보입니다.
그러므로 특정한 노드에서 가장 멀리 떨어진 리프 노드를 먼저 구한 뒤, 그 리프 노드에서 다시 가장 멀리 떨어진 리프 노드를 구하면 됩니다.

------

