### PR TITLE
트리의 지름

### DIFF
--- a/JangWoojin/[5]백준/1167_트리의 지름.cpp
+++ b/JangWoojin/[5]백준/1167_트리의 지름.cpp
@@ -1,0 +1,56 @@
+#include <iostream>
+#include <vector>
+#include <algorithm>
+#include <cstring>
+#define MAX 100001
+using namespace std;
+
+vector<pair<int, int>> graph[MAX];
+bool visited[MAX];
+int farthestNode = 0;
+int maxDistance = 0;
+
+void dfs (int node, int distance) {
+	if (visited[node])
+		return;
+	
+	visited[node] = true;
+	
+	for (int i = 0; i < graph[node].size(); ++i) {
+		int d = distance + graph[node][i].second;
+		dfs(graph[node][i].first, d);
+	}
+	if (distance > maxDistance) {
+		maxDistance = distance;
+		farthestNode = node;
+	}
+}
+
+int main() {
+	ios::sync_with_stdio(false);
+	cin.tie(0);
+	
+	int n;
+	cin >> n;
+	
+	while (n--) {
+		int from, to, distance;
+		cin >> from;
+		while (1) {
+			cin >> to;
+			if (to == -1)
+				break;
+			cin >> distance;
+			graph[from].push_back( {to, distance} );
+		}
+	}
+	
+	fill(visited, visited + MAX, false);
+	dfs(1, 0);
+	fill(visited, visited + MAX, false);
+	dfs(farthestNode, 0);
+	
+	cout << maxDistance << endl;
+	
+	return 0;
+}


### PR DESCRIPTION
##### **📘 풀이한 문제**

- 1167 - 트리의 지름 https://www.acmicpc.net/problem/1167

------

##### **⭐ 문제에서 주로 사용한 알고리즘**

* DFS

------

##### **📜 대략적인 코드 설명**

* 임의의 한 점에서 가장 먼 점을 찾은 후, 그 점으로부터 가장 먼 점까지의 거리가 트리의 지름이다.
* 따라서 두 번의 탐색을 구현했습니다.

------

