### PR TITLE
철로

### DIFF
--- a/ChanhuiSeok/[5]백준/13334-철로.cpp
+++ b/ChanhuiSeok/[5]백준/13334-철로.cpp
@@ -1,0 +1,84 @@
+#include <iostream>
+#include <vector>
+#include <algorithm>
+#include <string>
+#include <queue>
+
+using namespace std;
+// 블로그에 포스팅해서 정리할 만한 문제인 것 같다.
+// 참고로 라인 스위핑은 priority_queue를 많이 사용한다고 한다.
+
+#define pii pair<int, int>
+
+vector<pair<int, int>> input;
+
+int n, d;
+
+struct comp {
+	bool operator()(const pair<int, int>& a, const pair<int, int>& b) {
+		/* priority_queue는 comp를 정의 시, 일반적인 sort에서 comp함수 정의때와
+		정반대로 쓰면 된다. 오름차순을 아래처럼 작성했다. */
+		if (a.second == b.second) {
+			return a.first > b.first;
+		}
+		return a.second > b.second;
+	}
+};
+
+priority_queue<pii, vector<pii>, comp> inputQ;
+priority_queue<int, vector<int>, greater<int>> pq;
+
+bool compare(const pair<int, int>& a, const pair<int, int>& b) {
+	if (a.second != b.second) {
+		return a.second < b.second;
+	}
+	else if (a.second == b.second) {
+		return a.first < b.first;
+	}
+}
+
+int main() {
+
+	ios::sync_with_stdio(0);
+	cin.tie(0);
+	cout.tie(0);
+
+	cin >> n;
+	for (int i = 0; i < n; i++) {
+		int h, o;
+		cin >> h >> o;
+		if (h > o)inputQ.push({ o,h });
+		else inputQ.push({ h,o });
+	}
+	cin >> d;
+
+	int maxSize = 0;
+
+	// n개만큼 살펴본다.
+	while (!inputQ.empty()) {
+		int iR = inputQ.top().second;
+		int iL = inputQ.top().first;
+		inputQ.pop();
+
+		// iR-iL 사이즈가 d보다 작으면 일단 가능한 후보니까 그 왼쪽 끝점을 넣는다.
+		if (iR - iL <= d) {
+			pq.push(iL);
+		}
+
+		while (!pq.empty()) {
+			// 가능한 왼쪽 시작점 후보들이 있는 pq 에서 하나를 뽑아서
+			// 현재 살펴보고 있는 n번째 인풋의 오른쪽 끝값과의 거리를 계산하고
+			// 그 거리가 d 이하이면 나가서 다른 인풋을 계속 보며
+			// d 보다 큰 거리이면 가능한 왼쪽 시작점 후보에서 그것을 빼버린다.
+			int tmp = pq.top();
+			if (iR - tmp <= d) break;
+			else 
+				pq.pop();		
+		}
+		maxSize = max(maxSize, (int)pq.size());
+	}
+
+	cout << maxSize;
+
+	return 0;
+}


### PR DESCRIPTION
##### **📘 풀이한 문제**

- 13334번 - 철로 : https://www.acmicpc.net/problem/13334

------

##### **⭐ 문제에서 주로 사용한 알고리즘**

* 라인스위핑(스윕라인) 알고리즘에서 우선순위 큐를 사용하여 구현하였습니다.

------

##### **📜 대략적인 코드 설명**

* 맨 처음에 접근이 좀 힘들었습니다. 알아 보니 라인스위핑 문제는 우선순위 큐를 사용하는 경우가 꽤 있다고 합니다.
먼저 데이터들을 문제를 풀 수 있도록 정렬하고, 선을 한 번만 훑듯이 자료들을 보면서 조건에 맞게 최종적인 답안을 찾아가는 형식이었습니다.
* 모든 사람들을 끝점을 기준으로 오름차순 정렬해 놓은 다음, 그 사람들을 차례대로 하나씩 살펴 보면서 선분 L에 들어올 수 있는지 판단합니다. O(n)으로 n명의 사람에 대해 살펴봅니다.
* 이 때 사람 길이가 d 이하일 경우 포함 가능한 선분으로 보고 우선순위 큐에 시작점을 넣어 놓으며, 현재 새롭게 살펴보는 사람의 끝점에서 우선순위 큐의 top에 있는 시작점의 거리가 d 이하이면 괜찮지만, 그 거리가 더 길다면 우선순위 큐의 top에 있던 시작점을 가진 사람은 더 이상 선분 L에 포함될 수 없으므로 우선순위 큐에서 pop 합니다.
* 매 상황마다 우선순위 큐의 크기가 선분 L에 포함될 수 있는 사람들의 값과 같습니다.
* 한 번만 풀고 나중에 기억나지 않을까봐 블로그에 정리해 두었습니다. (https://chanhuiseok.github.io/posts/baek-28/)

------

