### PR TITLE
열쇠

### DIFF
--- a/ChanhuiSeok/[5]백준/9328-열쇠.cpp
+++ b/ChanhuiSeok/[5]백준/9328-열쇠.cpp
@@ -1,0 +1,112 @@
+#include <iostream>
+#include <vector>
+#include <algorithm>
+#include <string>
+#include <queue>
+#include <string>
+#include <map>
+#include <cstring>
+
+using namespace std;
+
+#define pii pair<int, int>
+
+int h, w;
+char arr[111][111];
+int visit[111][111];
+
+vector<int> answer;
+
+int dy[4] = { -1,1,0,0 };
+int dx[4] = { 0,0,-1,1 };
+
+int main() {
+
+	ios::sync_with_stdio(0);
+	cin.tie(0);
+	cout.tie(0);
+
+	int T;
+	string tmp;
+	cin >> T;
+
+	for (int t = 0; t < T; t++) {
+		cin >> h >> w; // 높이 h, 너비 w
+
+		memset(arr, 0, sizeof(arr));
+		for (int i = 1; i <= h; i++) {
+			for (int j = 1; j <= w; j++) {
+				cin >> arr[i][j];
+			}
+		}
+
+		map<char, int> maps; // 열쇠 유무를 저장하는 딕셔너리
+		// 알파벳 딕셔너리 - 열쇠 유무값을 저장할 딕셔너리 초기화
+		for (int i = 0; i < 26; i++) maps['A' + i] = 0;
+
+		cin >> tmp;
+		if (tmp != "0") {
+			for (int i = 0; i < tmp.size(); i++) maps[toupper(tmp[i])] = 1;
+		}
+		// visit 초기화
+		memset(visit, false, sizeof(visit));
+
+		map<char, vector<pii>> door; // 문의 위치를 저장하는 딕셔너리
+		queue<pii> q;
+
+		int res_cnt = 0;
+		q.push({ 0,0 });
+
+		while (!q.empty()) {
+			int idy = q.front().first;
+			int idx = q.front().second;
+			q.pop();
+
+			if (arr[idy][idx] == '$') res_cnt++;
+
+			for (int i = 0; i < 4; i++) {
+				int ty = idy + dy[i];
+				int tx = idx + dx[i];
+				// 방문할 수 없는 경우들 골라내기
+				if (ty < 0 || tx < 0 || ty > h + 1 || tx > w + 1)
+					continue;
+				if (visit[ty][tx])
+					continue;
+				if (arr[ty][tx] == '*')
+					continue;
+
+				// 문이었을 경우
+				if (isupper(arr[ty][tx])) {
+					// 문이었는데 열쇠가 없는 경우 위치를 door에 저장한다.
+					if (maps[arr[ty][tx]] == 0) {
+						door[arr[ty][tx]].push_back({ ty,tx });
+						continue;
+					}
+				}
+
+				// 열쇠였을 경우
+				if (islower(arr[ty][tx])) {
+					maps[toupper(arr[ty][tx])] = 1; // 열쇠 유무 true
+					// 이후 열쇠가 열 수 있는 문도 q에 넣는다.
+					int dy, dx;
+					for (int m = 0; m < door[toupper(arr[ty][tx])].size(); m++) {
+						int dy = door[toupper(arr[ty][tx])][m].first;
+						int dx = door[toupper(arr[ty][tx])][m].second;
+						q.push({ dy,dx });
+					}
+				}
+				// 열쇠가 있는 문이었거나 빈칸이거나 문서일 경우
+				visit[ty][tx] = true;
+				q.push({ ty,tx });
+			}
+		}
+
+		answer.push_back(res_cnt);
+		door.clear();
+	}
+
+	for (int i = 0; i < answer.size(); i++)
+		cout << answer[i] << '\n';
+
+	return 0;
+}


### PR DESCRIPTION
##### **📘 풀이한 문제**

- 9328-열쇠 : https://www.acmicpc.net/problem/9328

------

##### **⭐ 문제에서 주로 사용한 알고리즘**

* BFS를 사용하였습니다.

------

##### **📜 대략적인 코드 설명**


* 재차 정리해서 풀어 보니 불필요하거나 중복된 부분을 찾는 등 오류가 있음을 발견할 수 있었습니다.
* 상근이는 특정한 시작점이 없고 **바깥 어디에서나** 접근할 수 있기 때문에, '*', '.', 알파벳 등으로 이루어진 인풋 데이터들은 배열의 1행, 1열부터 넣고 상근이는 0행 0열부터 BFS를 시작하면 편합니다.
* BFS로 길을 탐색할 때, 해당 칸에 방문하였는데 **문이었는데 열쇠가 없었을 경우** 그 `문의 위치`를 저장해 둡니다.  그러다 **열쇠를 만났을 경우**, 그 열쇠로 열 수 있는 `방문했던 문의 위치`를 모두 큐에 push 합니다. 방문은 했었지만 딸 수는 없었던 그 문에 열쇠를 가지고 간 다음, 다시 그 문부터 BFS를 하게끔 해야 하기 때문입니다.
* map과 큐를 사용했습니다.

* (참고) 풀면서 왜 계속 통과가 안되는지 의문이었던 문제였습니다. 우선 이 문제는 BAPC 2013 기출문제라서 테스트 케이스 파일이 존재했기 때문에 그것과도 비교하면서 돌려 봤습니다. (테스트케이스는 http://2013.bapc.eu/docs/preliminary.zip 에서 받을 수 있으며 이 문제는 K번 문제입니다.) 그러나 백준에서는 위에서 제공하는 테스트케이스 외에도 다른 코너 케이스가 추가로 존재하기 때문에 위의 것을 다 맞았다고 해서 백준에서 통과되지는 않았습니다.
------

