### PR TITLE
트리 색칠하기

### DIFF
--- a/JangWoojin/[5]백준/1693_트리 색칠하기.py
+++ b/JangWoojin/[5]백준/1693_트리 색칠하기.py
@@ -1,0 +1,32 @@
+import sys
+from math import log2
+sys.setrecursionlimit(10 ** 8)
+input = sys.stdin.readline
+
+
+def dfs(root):
+    visited[root] = True
+    for c in graph[root]:
+        if visited[c]:
+            continue
+        dfs(c)
+        # i: root color, j: child color
+        for i in range(1, MAX):
+            dp[root][i] += min(dp[c][j] for j in range(1, MAX) if j != i)
+    for i in range(1, MAX):
+        dp[root][i] += i
+
+
+n = int(input())
+MAX = int(log2(n)) + 2
+graph = [[] for _ in range(n+1)]
+visited = [False for _ in range(n+1)]
+dp = [[0] * MAX for _ in range(n+1)]
+
+for _ in range(n-1):
+    u, v = map(int, input().split())
+    graph[u].append(v)
+    graph[v].append(u)
+
+dfs(1)
+print(min(dp[1][1:]))


### PR DESCRIPTION
##### **📘 풀이한 문제**

- 1693 트리 색칠하기

------

##### **⭐ 문제에서 주로 사용한 알고리즘**

* 트리 DP

------

##### **📜 대략적인 코드 설명**

* 여기서 핵심은 트리를 색칠하는데 필요한 색깔의 수가 logN을 넘지 않는다는 것입니다. T(N)을 문제 조건에 맞도록 루트 노드에 N을 칠했을 때의 트리 크기라고 한다면 T(N) >= T(1) + T(2) + ... + T(N-1) + 1이라는 식이 성립됩니다. 여기서 T(1) = 1, T(2) = T(1) + 1 이므로 T(N) >= 2^(N-1)입니다. 정점의 수가 2^16 < 100,000 < 2^17이기 때문에 최대 18개의 색깔로 트리를 칠할 수 있습니다.
참조: https://www.acmicpc.net/board/view/13972
* dp[i][c]: 루트 노드  i를 색깔 c로 칠했을 때의 서브트리 최소 크기
* 단말 노드에서부터 dp를 갱신합니다.

------

