### PR TITLE
엘리베이터

### DIFF
--- a/ChanhuiSeok/[5]백준/2593-엘리베이터.cpp
+++ b/ChanhuiSeok/[5]백준/2593-엘리베이터.cpp
@@ -1,0 +1,103 @@
+#include <iostream>
+#include <vector>
+#include <algorithm>
+#include <string>
+#include <vector>
+#include <queue>
+
+using namespace std;
+
+vector<int> floors[101]; // 1~100번 엘리베이터에 연결된 층을 표시
+vector<int> elevator[100001]; // 1~100000층에서 갈 수 있는 엘리베이터 번호를 표시
+priority_queue<pair<int, int>> pq;
+
+int ele_cnt[101];
+int ele_parent[101];
+
+int A, B, N, M; // N층, M대의 엘리베이터
+
+void dijkstra() {
+
+	// 시작 층과 연결된 모든 엘리베이터는 탄 횟수를 1로 초기화시킨다. (1번만 타도 갈 수 있다는 의미)
+	for (int i = 0; i < elevator[A].size(); i++) {
+		ele_cnt[elevator[A][i]] = 1;
+		pq.push({ -1, elevator[A][i] });
+	}
+
+	while (!pq.empty()) {
+		int eleNum = pq.top().second;
+		int tempC = pq.top().first * -1;
+		pq.pop();
+
+		if (tempC <= ele_cnt[eleNum]) {
+			// 큐에서 뽑은 엘리베이터 번호와 연결된 모든 층을 살펴본다.
+			for (int i = 0; i < floors[eleNum].size(); i++) {
+				int tempFloor = floors[eleNum][i];
+				for (int j = 0; j < elevator[tempFloor].size(); j++) {
+					int nextEle = elevator[tempFloor][j];
+					// 연결된 층에서 탈 수 있는 다음 엘리베이터 번호
+
+					// 다음 엘리베이터에 탄 횟수가 한 번도 없거나,
+					// 다음 엘리베이터를 탄 횟수보다 tempC + 1이 더 작을 경우
+					// 값을 그것으로 갱신해 준다.
+					if (ele_cnt[nextEle] == 0 || tempC + 1 < ele_cnt[nextEle]) {
+						ele_cnt[nextEle] = tempC + 1;
+						ele_parent[nextEle] = eleNum; // 다음 엘리베이터 전에 탄 것은 eleNum으로 표시
+						pq.push({ (tempC + 1) * -1, nextEle });
+					}
+				}
+			}
+
+		}
+	}
+}
+
+void print(int num) {
+	if (num == 0) return;
+	print(ele_parent[num]);
+	printf("%d\n", num);
+}
+
+
+int main() {
+
+	ios::sync_with_stdio(0);
+	cin.tie(0);
+
+	cin >> N >> M;
+	for (int i = 1; i <= M; i++) { // 엘리베이터 갯수만큼 반복
+		int X, Y;
+		cin >> X >> Y;
+
+		while (X <= N) {
+			// 4, 3을 입력받을 경우 4층, 7층, 10층, .. 이 floor[i] 에 연결
+			floors[i].push_back(X);
+			elevator[X].push_back(i);
+			X += Y;
+		}
+	}
+	cin >> A >> B;
+
+	dijkstra();
+
+	int ans = 987654321;
+	int last = 0;
+
+	// B층과 연결된 엘리베이터들 에서 최솟값 찾기
+	for (int i = 0; i < elevator[B].size(); i++) {
+		if (ele_cnt[elevator[B][i]] < ans) {
+			ans = ele_cnt[elevator[B][i]];
+			last = elevator[B][i];
+		}
+	}
+
+	if (ans == 987654321 || ans == 0) printf("-1\n");
+	else {
+		printf("%d\n", ans);
+		print(last);
+	}
+
+
+
+	return 0;
+}


### PR DESCRIPTION
##### **📘 풀이한 문제**

- 2593-엘리베이터 : https://www.acmicpc.net/problem/2593

------

##### **⭐ 문제에서 주로 사용한 알고리즘**

* 다익스트라를 메인으로 사용하였습니다. (기존의 다익스트라 문제와는 다소 차이가 있어서 어려움이 많았습니다.)

------

##### **📜 대략적인 코드 설명**

* 각 엘리베이터가 내릴 수 있는 층을 저장한 floors 벡터, 그리고 해당 층에 설 수 있는 엘리베이터 번호를 저장한 elevator 벡터를 만들어서 입력을 받습니다. (각 엘리베이터 입장과 각 층의 입장에서)
* 예제에서 floors[1] = {4,7,10}, floors[2] = {7,12}, floors[3] = {4,8,12} 가 됩니다. 1번 엘리베이터는 4, 7, 10층에 선다는 의미입니다.
* elevator[4] = {1, 3} 같은 식으로, 4번 층에는 1번과 3번 엘리베이터가 설 수 있다는 의미입니다.
* 특정 번호의 엘리베이터에 탑승한 횟수를 기록하기 위한 카운트 배열을 선언합니다. (**1)
* 타야 하는 엘리베이터의 기록을 출력해야 하므로, 탑승한 횟수를 최소로 만족시키면서 직전에 탑승한 엘리베이터 번호를 기록하는 배열을 선언합니다. (**2)

* A(층) -> B(층)으로 가는 최단거리를 구하는 것으로 다익스트라 알고리즘을 활용합니다.
* 다익스트라를 시작하기 전, 처음 시작층(A층)에서 탈 수 있는 모든 엘리베이터들(즉, 시작층이 10층이었을 경우 elevator[10] 에 있는 번호들)은 탑승한 횟수를 1로 설정하고 우선순위 큐에 넣습니다.
* 큐가 빌 때 까지 다익스트라 알고리즘을 사용합니다. 큐에서 뽑은 엘리베이터와 연결된 모든 층(floors)을 살펴보면서 그 층에서 탈 수 있는 다음 엘리베이터들을 모두 살펴봅니다. 다음 엘리베이터에 기록된 탑승 횟수가 (1) 0이거나, (2) '큐에서 뽑은 엘리베이터의 탑승 횟수 + 1'이 더 작을 경우 이 값으로 갱신하고, 우선순위 큐에 넣습니다. 이 때, 다음 엘리베이터에 타기 직전 엘리베이터 번호는 현재 큐에서 뽑았던 그 엘리베이터임을 추가로 기록해 둡니다. (**2 배열)
* 모든 알고리즘이 끝나면 탑승 횟수를 기록하는 배열의 값들이 갱신됩니다.
* 마지막으로 B층과 연결된 엘리베이터들 중, 탑승 횟수를 기록한 배열을 보고 탑승한 횟수가 가장 적은 엘리베이터를 선택합니다.

------

