### PR TITLE
K번째 최단경로 찾기

### DIFF
--- a/ChanhuiSeok/[5]백준/1854-K번째최단경로찾기.cpp
+++ b/ChanhuiSeok/[5]백준/1854-K번째최단경로찾기.cpp
@@ -1,0 +1,76 @@
+#include <iostream>
+#include <vector>
+#include <map>
+#include <queue>
+#include <string>
+#include <set>
+#include <algorithm>
+
+#define pii pair<int,int>
+#define INF 987654321
+
+using namespace std;
+
+int n, m, k;
+vector<pii> node[1002];
+priority_queue<int> que[1002];
+
+void simulation(int start) {
+	// dist 초기화
+	priority_queue<pii, vector<pii>, greater<>> pq;
+	que[start].push(0);
+	pq.push({ 0, start });
+
+	while (!pq.empty()) {
+		int cur = pq.top().second;
+		int curdist = pq.top().first;
+		pq.pop();
+
+		for (auto temp : node[cur]) {
+			int next = temp.second;
+			int nextdist = curdist + temp.first;
+
+			// 각 노드의 큐에는 항상 최대 k개까지 가지고 있을 수 있다.
+			if (que[next].size() < k) {
+				que[next].push(nextdist);
+				pq.push({ nextdist, next });
+			}
+			// 만약 큐에 k개 이상 가득 차 있었는데
+			// 큐에 가장 큰 값이 현재 nextdist 값보다 더 컸을 경우,
+			// 큐에서 가장 큰 값을 삭제하고, nextdist 값을 넣어서
+			// k번째 값을 유지한다.
+			else if (que[next].top() > nextdist) {
+				que[next].pop();
+				que[next].push(nextdist);
+				pq.push({ nextdist, next });
+			}
+		}
+	}
+}
+
+int main() {
+
+	ios::sync_with_stdio(0);
+	cin.tie(0);
+
+	cin >> n >> m >> k;
+
+	for (int i = 0; i < m; i++) {
+		int a, b, c;
+		cin >> a >> b >> c;
+		node[a].push_back({ c,b });
+	}
+
+	simulation(1);
+
+	for (int i = 1; i <= n; i++) {
+		if (que[i].size() < k) {
+			cout << -1 << '\n';
+		}
+		else if (que[i].size() >= k) {
+			cout << que[i].top() << '\n';
+		}
+	}
+
+	return 0;
+}


### PR DESCRIPTION
##### **📘 풀이한 문제**

- 1854-K번째 최단경로 찾기 : https://www.acmicpc.net/problem/1854

------

##### **⭐ 문제에서 주로 사용한 알고리즘**

* 다익스트라
------

##### **📜 대략적인 코드 설명**

* 다익스트라 알고리즘을 사용하는데, K번째 최단거리를 찾는 것이므로 K가 2 이상이라면 더 느리게 가는 경로들도 추가적으로 구해야 합니다.
* 각 노드마다 추가적인 max heap을 선언해 놓고, 그 노드로 가는 경로들이 나올 때마다 heap에 계속 추가합니다. (즉 다익스트라 알고리즘을 구현할 때, 거리값 배열을 갱신하는 부분 없이 가능한 경로를 모두 보고 우선순위 큐에 넣습니다.)
* heap의 사이즈는 K개를 유지해야 합니다. K개로 가득 찼는데 좀 더 짧은 경로가 찾아졌으면, 가장 큰 값을 빼고 heap에 추가합니다.

------

