### PR TITLE
트리의 지름

### DIFF
--- a/minseokKim/[5]백준/1167-트리의 지름.java
+++ b/minseokKim/[5]백준/1167-트리의 지름.java
@@ -1,0 +1,70 @@
+import java.util.*;
+import java.io.*;
+public class Main {
+	public static int far_node = 0;
+	public static int max = -1;
+	public static LinkedList[] list;
+	public static boolean[] visited;
+	public static void main(String[] args)throws Exception
+	{
+		BufferedReader br = new BufferedReader (new InputStreamReader(System.in));
+		int v = Integer.parseInt(br.readLine());
+		list = new LinkedList[100001];
+		visited = new boolean[100001];
+		for(int i = 1; i <= 100000; i++)
+		{
+			list[i] = new LinkedList<node>();
+		}
+		for(int i = 1 ; i <= v; i++)
+		{
+			StringTokenizer st = new StringTokenizer(br.readLine());
+			int row = Integer.parseInt(st.nextToken());
+			while(true)
+			{
+				int dest = Integer.parseInt(st.nextToken());
+				if(dest == -1)
+					break;
+				int len = Integer.parseInt(st.nextToken());
+				node no = new node(dest,len);
+				list[row].add(no);
+			}
+		}
+		visited[1] = true;
+		dfs(1,0);
+		visited[1] = false;
+		visited = new boolean[100001];
+		visited[far_node] = true;
+		dfs(far_node,0);
+		visited[far_node] = false;
+		System.out.println(max);
+	}
+	public static void dfs(int cur, int sum)
+	{
+		Iterator it = list[cur].iterator();
+		while(it.hasNext())
+		{
+			node next = (node)it.next();
+			if(visited[next.dest])
+				continue;
+			visited[cur] = true;
+			dfs(next.dest, sum+next.len);
+			visited[cur] = false;
+		}
+		if(max < sum)
+		{
+			max = sum;
+			far_node = cur;
+		}
+	}
+}
+class node
+{
+	int dest;
+	int len;
+	node(int i,int j)
+	{
+		dest = i;
+		len = j;
+	}
+	
+}


### PR DESCRIPTION
##### **📘 풀이한 문제**

- 1167 트리의 지름
https://www.acmicpc.net/problem/1167
------

##### **⭐ 문제에서 주로 사용한 알고리즘**

* dfs 2번

------

##### **📜 대략적인 코드 설명**

* 임의의 점에서 dfs 한 번 해서 임의의 점에서 가장 먼 노드로 이동,
해당 노드에서 한 번 더 dfs 하면 가장 긴 지름이 나옵니다.

------

