### PR TITLE
외판원 순회

### DIFF
--- a/wan2good/백준/12주차_외판원순회.py
+++ b/wan2good/백준/12주차_외판원순회.py
@@ -1,0 +1,22 @@
+input=__import__('sys').stdin.readline
+MIS=lambda:map(int,input().rstrip().split())
+n=int(input().rstrip());board=[];INF=2e10
+for _ in range(n):
+    board.append(list(MIS()))
+dp=[[None]*(1<<n) for _ in range(n)]
+
+def find_path(last,visited): 
+    if visited==(1<<n)-1:  
+        return board[last][0] or INF  
+
+    if dp[last][visited] is not None:  
+        return dp[last][visited]
+
+    tmp=INF
+    for city in range(n):
+        if visited&(1<<city)==0 and board[last][city]!=0:
+            tmp=min(tmp,find_path(city,visited | (1<<city)) + board[last][city])
+    dp[last][visited]=tmp
+    return tmp
+
+print(find_path(0,1<<0))


### PR DESCRIPTION
##### **📘 풀이한 문제**

- 2098 외판원 순회 : https://www.acmicpc.net/problem/2098

------

##### **⭐ 문제에서 주로 사용한 알고리즘**

* 비트마스크,DP

------

##### **📜 대략적인 코드 설명**

- 잘 알려진 TSP라고 불리는 문제입니다
- 비트마스크와 DP배열을 활용하여 문제를 해결해야 시간초과가 나지 않습니다.
- DP 배열은 DP[현재노드][방문노드]=비용 으로 나타냅니다.
- DP[1][6]은 현재 1번에 있고 6=0110(2), 즉 1,2를 방문한 상태라는 뜻입니다.
- 이를 토대로 모두 방문한 다음 처음으로 돌아가는 경로를 더해주고 그 중 최솟값을 출력합니다.
------

