### PR TITLE
거의 최단경로

### DIFF
--- a/wan2good/백준/15주차_거의최단경로.py
+++ b/wan2good/백준/15주차_거의최단경로.py
@@ -1,0 +1,52 @@
+import heapq
+from collections import deque
+input=__import__('sys').stdin.readline
+MIS=lambda:map(int,input().rstrip().split())
+INF=2e10
+
+while True:
+    n,m=MIS()
+    if n==0 and m==0: break
+    s,e=MIS()
+    graph=[{} for _ in range(n)]
+    re_graph=[[] for _ in range(n)]
+    check=set()
+    for _ in range(m):
+        u,v,p=MIS()
+        graph[u][v]=p
+        re_graph[v].append(u)
+
+    def dijkstra(start,end):   
+        distance=[INF]*n
+        distance[start]=0
+        q=[]
+        heapq.heappush(q,(0,start))
+        while q:
+            dist,now=heapq.heappop(q)
+            if dist>distance[now]: continue
+
+            for i in graph[now]:
+                cost=graph[now][i]
+                if distance[i]>distance[now]+cost:
+                    distance[i]=distance[now]+cost
+                    heapq.heappush(q,(distance[i],i))
+        return distance
+    
+    distance=dijkstra(s,e)
+
+    def bfs():
+        q=deque();q.append(e)
+        while q:
+            now=q.popleft()
+            if now==s: continue
+            for prev_node in re_graph[now]:
+                if distance[now]==distance[prev_node]+graph[prev_node][now]:
+                    if (prev_node,now) not in check:
+                        check.add((prev_node,now))
+                        q.append((prev_node))
+    bfs()
+    for a,b in check:
+        del graph[a][b]
+    distance=dijkstra(s,e)
+
+    print(distance[e] if distance[e]!=INF else -1)


### PR DESCRIPTION
##### **📘 풀이한 문제**

- 5719 거의 최단 경로: https://www.acmicpc.net/problem/5719

------

##### **⭐ 문제에서 주로 사용한 알고리즘**

* 다익스트라, BFS

------

##### **📜 대략적인 코드 설명**

- 다익스트라를 한번 수행해서 최단 경로를 알아내고 그 경로를 제외한 graph에서 다익스트라를 한번 더 수행합니다.
- 최단 경로는 BFS를 수행해서 역으로 경로를 추적합니다.
- 추적하는 과정에서 check라는 set에 추가하고, 추적이 끝나면 graph에서 최단 경로를 제거해 줍니다.
- graph를 만들 때 리스트로 만들다 보니 메모리 초과가 나서 딕셔너리를 활용하였습니다.
- 역추적에 사용할 re_graph도 생성하였습니다.

------

