### PR TITLE
트리의 지름

### DIFF
--- a/wan2good/백준/15주차_트리의지름.py
+++ b/wan2good/백준/15주차_트리의지름.py
@@ -1,0 +1,27 @@
+from collections import deque
+
+input=__import__('sys').stdin.readline
+MIS=lambda:map(int,input().rstrip().split())
+v=int(input().rstrip());adj=[[] for _ in range(v+1)]
+for _ in range(v):
+    data=list(MIS())
+    for i in range(1,len(data)-2,2):
+        adj[data[0]].append((data[i],data[i+1]))
+
+def bfs(start):
+    maxNode,maxDist=0,0
+    check=[False]*(v+1);check[start]=True
+    q=deque();q.append((start,0))
+    while q:
+        now,dist=q.popleft()
+        for nextNode,cost in adj[now]:
+            if not check[nextNode]:
+                check[nextNode]=True
+                q.append((nextNode,cost+dist))
+                if maxDist<cost+dist:
+                    maxDist=cost+dist
+                    maxNode=nextNode
+    return maxNode,maxDist
+
+node,dist=bfs(1)
+print(bfs(node)[1])


### PR DESCRIPTION
##### **📘 풀이한 문제**

- 1167 트리의 지름 : https://www.acmicpc.net/problem/1167

------

##### **⭐ 문제에서 주로 사용한 알고리즘**

* BFS

------

##### **📜 대략적인 코드 설명**

* 입력값으로 인접리스트를 구성합니다.
* 트리의 지름이란 임의의 노드 x에서 가장 비용이 많이 드는 y를 찾고, y에서 다시 비용이 많이 드는 z를 찾았을 때, y와 z 사이의 거리가 트리의 지름입니다.
* 임의의 노드를 잡고 BFS를 수행합니다. BFS를 수행할 때 최대비용과 그 때의 노드를 따로 저장합니다
* 최대비용이 드는 노드를 시작으로 다시 최대비용이 드는 노드를 찾습니다.
* 그 때 비용을 출력합니다.

------

