### PR TITLE
멀티탭 스케줄링

### DIFF
--- a/wan2good/백준/23주차_멀티탭스케줄링.java
+++ b/wan2good/백준/23주차_멀티탭스케줄링.java
@@ -1,0 +1,71 @@
+import java.util.*;
+import java.io.*;
+
+public class Main {
+
+   static int n,k;
+   static int[] order;
+   static int[][] count;
+   static int[] multiTap;
+   
+   public static void main(String[] args) throws IOException{
+	   BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+	   StringTokenizer st = new StringTokenizer(br.readLine());
+	   n = Integer.parseInt(st.nextToken());
+	   k = Integer.parseInt(st.nextToken());
+	   
+	   order = new int[k];
+	   
+	   st = new StringTokenizer(br.readLine());
+	   for(int i=0; i<k; i++) 
+	   {
+		   int num = Integer.parseInt(st.nextToken());
+		   order[i] = num;
+	   }
+	   
+	   int last=0;
+	   multiTap = new int[n];
+	   int cur,cnt=0;
+	   for(int i=0; i<k; i++) {
+		   boolean flag=false;
+		   cur = order[i];
+		   for(int idx=0; idx<n; idx++) {
+			   if(multiTap[idx]==cur) {
+				   flag=true;
+				   break;
+			   }
+			   else if(multiTap[idx]==0) {
+				   flag=true;
+				   multiTap[idx]=cur;
+				   break;
+			   }
+		   }
+		   if(flag)
+			   continue;
+		   
+		   cnt+=1;
+		   int resultMultitapIdx=0;
+		   int orderIdx=Integer.MIN_VALUE;
+		   for(int idx=0; idx<n; idx++) {
+			   int len=0;
+			   for(int x=i+1; x<k; x++) {
+				   if(multiTap[idx]!=order[x])
+					   len++;
+				   else
+					   break;
+			   }
+			   if(len > orderIdx) {
+				   resultMultitapIdx = idx;
+				   orderIdx = len;
+			   }
+		   }
+		   
+		   multiTap[resultMultitapIdx]=cur;
+			   
+		   
+	   }
+      
+      System.out.println(cnt);
+   }
+
+}

--- a/wan2good/백준/23주차_멀티탭스케줄링.java
+++ b/wan2good/백준/23주차_멀티탭스케줄링.java
@@ -64,7 +64,7 @@ public class Main {
 			   
 		   
 	   }
-      
+
       System.out.println(cnt);
    }
 


### PR DESCRIPTION
##### **📘 풀이한 문제**

- 1700 멀티탭 스케줄링 : https://www.acmicpc.net/problem/1700

------

##### **⭐ 문제에서 주로 사용한 알고리즘**

* 그리디

------

##### **📜 대략적인 코드 설명**

* 물건이 멀티탭에 꽂혀있는지, 비어있는지 확인하고 둘중 하나라도 조건에 걸린다면 다음 물건으로 넘어갑니다.
* 멀티탭이 꽉 차있을 경우, 멀티탭에 꽂혀있는 물건들 중 가장 늦게 사용되거나, 후에 사용되지 않을 멀티탭 번호를 찾아 새로 들어오는 물건과 바꿔줍니다.
* 횟수를 출력합니다.

------

