### PR TITLE
국왕의 방문

### DIFF
--- a/wan2good/백준/29주차_국왕의방문.java
+++ b/wan2good/백준/29주차_국왕의방문.java
@@ -1,0 +1,106 @@
+import java.io.*;
+import java.util.*;
+
+public class Main {
+	
+	static int n,m;
+	static int a,b,k,g;
+	static int[] king;
+	static int[][] map;
+	static int[][] start_king_distance;
+	static int[][] end_king_distance;
+	static ArrayList<Data>[] graph;
+	static PriorityQueue<Data> pq;
+	
+	public static void main(String[] args) throws IOException {
+    	BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    	StringTokenizer st = new StringTokenizer(br.readLine());
+    	
+    	n = Integer.parseInt(st.nextToken());
+    	m = Integer.parseInt(st.nextToken());
+    	
+    	map = new int[n+1][n+1];
+    	graph = new ArrayList[n+1];
+    	for(int i=1; i<=n; i++) {
+    		graph[i] = new ArrayList<>();
+    	}
+    	
+    	st = new StringTokenizer(br.readLine());
+    	a = Integer.parseInt(st.nextToken());
+    	b = Integer.parseInt(st.nextToken());
+    	k = Integer.parseInt(st.nextToken());
+    	g = Integer.parseInt(st.nextToken());
+    	
+    	king = new int[g];
+    	st = new StringTokenizer(br.readLine());
+    	for(int i=0; i<g; i++) {
+    		king[i] = Integer.parseInt(st.nextToken());
+    	}
+    	
+    	for(int i=0; i<m; i++) {
+    		st = new StringTokenizer(br.readLine());
+    		int u = Integer.parseInt(st.nextToken());
+    		int v = Integer.parseInt(st.nextToken());
+    		int l = Integer.parseInt(st.nextToken());
+    		
+    		graph[u].add(new Data(v,l));
+    		graph[v].add(new Data(u,l));
+    		map[u][v] = l;
+    		map[v][u] = l;
+    	}
+    	
+    	start_king_distance = new int[n+1][n+1];
+    	end_king_distance = new int[n+1][n+1];
+    	int king_dist = 0;
+    	for(int i=0; i<g-1; i++) {
+    		start_king_distance[king[i]][king[i+1]] = king_dist;
+    		end_king_distance[king[i]][king[i+1]] = king_dist + map[king[i]][king[i+1]];
+    		
+    		start_king_distance[king[i+1]][king[i]] = king_dist;
+    		end_king_distance[king[i+1]][king[i]] = king_dist + map[king[i]][king[i+1]];
+    		king_dist += map[king[i]][king[i+1]];
+    	}
+    	
+    	
+    	pq = new PriorityQueue<>((a,b) -> a.cost - b.cost);
+    	int[] result = dijkstra(a);
+    	System.out.println(result[b]-k);
+	}
+	
+	private static int[] dijkstra(int start) {
+		int[] distance = new int[n+1];
+		Arrays.fill(distance, 987654321);
+		pq.offer(new Data(a,k));
+		distance[start]=k;
+		while(!pq.isEmpty()) {
+			Data cur = pq.poll();
+			int now = cur.cur;
+			int dist = cur.cost;
+			
+			if(dist > distance[now])
+				continue;
+			
+			for(Data next : graph[now]) {
+				int cost = dist+next.cost;
+				if(start_king_distance[now][next.cur]<=dist && dist<end_king_distance[now][next.cur]) {
+					cost += end_king_distance[now][next.cur]-dist;
+				}
+				
+				if(cost < distance[next.cur]) {
+					distance[next.cur] = cost;
+					pq.offer(new Data(next.cur, cost));
+				}
+			}
+		}
+		
+		return distance;
+	}
+	
+	static class Data{
+		int cur,cost;
+		Data(int cur, int cost){
+			this.cur = cur;
+			this.cost = cost;
+		}
+	}
+}


### PR DESCRIPTION
##### **📘 풀이한 문제**

- 2982 국왕의 방문 : https://www.acmicpc.net/problem/2982

------

##### **⭐ 문제에서 주로 사용한 알고리즘**

* 다익스트라

------

##### **📜 대략적인 코드 설명**

* 국왕이 지나가는 교차로사이의 도로는 국왕이 지나는 시간동안 통제가 필요합니다.
* 국왕이 해당 교차로를 진입하는 시간과 통과하고 지나가는 시간을 추가로 저장합니다.
* 상근이가 해당 교차로에 진입한 시간이 국왕이 지나는 시간대 사이에 속하면 국왕이 지나갈 때 까지 기다려야 하므로 시간을 그 차이만큼 더해줍니다.
* 위 과정으로 다익스트라를 수행하면 최소 비용을 구할 수 있습니다.

------

