### PR TITLE
냅색문제

### DIFF
--- a/COZAK92/36주차/1450.냅색문제.cpp
+++ b/COZAK92/36주차/1450.냅색문제.cpp
@@ -1,0 +1,70 @@
+#include <bits/stdc++.h>
+using namespace std;
+#define FOR(i,m,n) for(int i=(m);i<(n);i++)
+#define REP(i,n) FOR(i,0,n)
+#define ALL(v) (v).begin(),(v).end()
+#define debug(x) cerr << #x << " is " << x << "\n"
+using ll = long long;
+using pii = pair<int,int>;
+constexpr int INF = 0x3f3f3f3f;
+constexpr long long LINF = 0x3f3f3f3f3f3f3f3fLL;
+constexpr double EPS = 1e-8;
+constexpr int MOD = 1000000007;
+// constexpr int MOD = 998244353;
+constexpr int dy[] = {1, 0, -1, 0}, dx[] = {0, -1, 0, 1};
+constexpr int dy8[] = {1, 1, 0, -1, -1, -1, 0, 1}, dx8[] = {0, -1, -1, -1, 0, 1, 1, 1};
+const int MX = 50;
+
+ll arr[MX];
+unordered_map<ll,ll> s1;
+vector<ll> l,r;
+
+int n,c,h;
+int ans = 0;
+void searchLeft(int index, int sum){
+    if(sum > c) return;
+    if( index == h){
+        l.push_back(sum);
+        return;
+    }
+
+    searchLeft(index + 1, sum + arr[index]);
+    searchLeft(index + 1, sum);
+}
+void serachRight(int index, int sum){
+    if(sum > c) return;
+    if( index == n){
+        r.push_back(sum);
+        return;
+    }
+
+    serachRight(index + 1, sum + arr[index]);
+    serachRight(index + 1, sum);
+}
+
+void solve(){
+    cin >> n >> c;
+    h = n/2;
+    REP(i,n) cin >> arr[i];
+    s1[0] = 1;
+    searchLeft(0,0);
+    serachRight(h,0);
+    sort(ALL(l));
+    sort(ALL(r));
+
+    for(auto a : l){
+        int R = upper_bound(ALL(r), c - a) - r.begin();
+        ans += R;
+    }
+
+    cout << ans;
+    
+}
+
+
+int main(){
+    ios::sync_with_stdio(false);
+    cin.tie(NULL);
+    cout.tie(NULL);
+    solve();
+}


### PR DESCRIPTION
##### **📘 풀이한 문제**
------
- 백준 1450 냅색문제

##### **⭐ 문제에서 주로 사용한 알고리즘**

------
백준 1208 부분수열의 합 2 와 비슷하게 MITM 알고리즘을 사용하여 풀었습니다. 다른 점이라면 1208 문제는 해당 수가 되는 경우이지만 이 문제는 해당 수 보다 작은 경우이므로 이분탐색을 통해서 풀었습니다.

##### **📜 대략적인 코드 설명**

------
우선 왼쪽 오른쪽을 나눠 모든 합의 경우의 수를 구합니다. 왼쪽 오른쪽으로 나눈 이유는 전체를 한번에 탐색할 경우 최악의 경우 N^30의 경우의 수를 탐색해야 하기 때문에 시간내에는 절대 풀 수 없기 때문입니다.
그 이후 왼쪽을 기준합으로 (어느쪽을 기준합으로 잡아도 상관없습니다) `C - sumL`의 원소가 오른쪽 합에 있는지 이분탐색합니다. 해당 원소보다 작은 원소들이 현재 sumL과 더했을때  C를 넘지 않는 경우이기떄문에 다 더해 답을 구해줍니다.

