### PR TITLE
원숭이 스포츠

### DIFF
--- a/kuyhochung/1. 매주 문제풀이/49주차/16438_원숭이 스포츠.cpp
+++ b/kuyhochung/1. 매주 문제풀이/49주차/16438_원숭이 스포츠.cpp
@@ -1,0 +1,53 @@
+#include <iostream>
+#include <vector>
+#include <string>
+#include <algorithm>
+using namespace std;
+
+int n;
+int print_count = 0;
+char answer[8][101];
+
+void combination (int start, int end, int depth) {
+    if (start >= end || depth == 7) return;
+    print_count = max(print_count, depth);
+    
+    int mid = (start + end) / 2;
+    
+    for (int i = start; i <= end; i++) {
+        if (i <= mid) answer[depth][i] = 'A';
+        else answer[depth][i] = 'B';
+    }
+    
+    combination(start, mid, depth+1);
+    combination(mid+1, end, depth+1);
+}
+
+int main() {
+    ios::sync_with_stdio(false); cin.tie(NULL); cout.tie(NULL);
+    cin >> n;
+
+    combination(1, n, 0);
+
+    for (int i = 0; i <= print_count; i++) {
+        for (int j = 1; j <= n; j++) {
+            if (answer[i][j] == '\0') {
+                if (j % 2 == 1) answer[i][j] = 'A';
+                else answer[i][j] = 'B';
+            }
+            cout << answer[i][j];
+        }
+        cout << '\n';
+    }
+    
+    int b_loc = 0;
+    while(print_count != 6) {
+        for (int i = 0; i < n; i++) {
+            if (i == b_loc) cout << 'B'; else cout << 'A';
+        }
+        cout << '\n';
+        b_loc = (b_loc+1) % n; print_count++;
+    }
+    
+    return 0;
+}


### PR DESCRIPTION
##### **📘 풀이한 문제**

- 백준 16438번 문제 원숭이 스포츠

------

##### **⭐ 문제에서 주로 사용한 알고리즘**

* 분할 정복

------

##### **📜 대략적인 코드 설명**

* N은 최대 99이므로, 2^7 = 128보다 작고, 따라서 7회 (7주) 이내에 모든 i와 j가 서로 다른 팀에 속하는 경우를 만들 수 있습니다.
* 가지고 있는 원숭이 팀을 반으로 나누어 A, B에 포함시키는 방법을 재귀적으로 반복합니다.
* 빈 원숭이 칸은 A 또는 B를 적절히 넣어 주고, 7회 미만 동안 모든 경우의 수가 다 등장한 경우 7회를 채울 때까지 추가 출력을 합니다.
* https://katfun.tistory.com/entry/%EB%B0%B1%EC%A4%80-16438%EB%B2%88-%EC%9B%90%EC%88%AD%EC%9D%B4-%EC%8A%A4%ED%8F%AC%EC%B8%A0

------

